### PR TITLE
Do not read more than necessary (from a stream).

### DIFF
--- a/test/bencode_test.janet
+++ b/test/bencode_test.janet
@@ -152,6 +152,28 @@
             "d3:ham4:eggs4:costi5e3:forl4:finn6:joanna5:emilye3:mapd5:apple3:red4:pear5:greenee"
             :keyword-dicts false)))
 
+  (do
+    (def s (net/server "localhost" "12499" (fn [stream] (:write stream "d4:costi5e3:ham4:eggse"))))
+    (defer (:close s)
+      (def stream (net/connect "localhost" "12499"))
+      (var result nil)
+      (try
+        (ev/with-deadline 1 (set result (bencode/read-stream stream)))
+        ([err] (set result err)))
+      (test "Read dictionary from stream"
+        (is (= {:ham "eggs" :cost 5} result)))))
+
+  (do
+    (def s (net/server "localhost" "12499" (fn [stream] (:write stream "l6:cheese3:ham4:eggse"))))
+    (defer (:close s)
+      (def stream (net/connect "localhost" "12499"))
+      (var result nil)
+      (try
+        (ev/with-deadline 1 (set result (bencode/read-stream stream)))
+        ([err] (set result err)))
+      (test "Read list from stream"
+        (is (= ["cheese" "ham" "eggs"] result)))))
+
   (let [reader (bencode/reader "13:Hello, World!13:Hello, World!")]
     (loop [value :iterate (bencode/read reader)]
       (test "Read several values"


### PR DESCRIPTION
If we read from a stream we should not advance the reader past the end if the parsed value, because if we do not get another byte from a stream we get stuck.

This change adds a `level` parameter to `read-bencode`, `read-dictionary`, and `read-list`, so we can decide not to advance the reader if we are at the end of a top-level list of dict (ie. level == 0)